### PR TITLE
Cache FXML loaders for list cells

### DIFF
--- a/src/Controllers/MessageCustomCellController.java
+++ b/src/Controllers/MessageCustomCellController.java
@@ -12,49 +12,89 @@ import java.io.IOException;
 
 public class MessageCustomCellController extends ListCell<MessageViewModel> {
 
-    @FXML
-    private GridPane root;
+    private final MessageCell incomingMessage;
+    private final MessageCell outgoingMessage;
+    private final ImageCell incomingImage;
+    private final ImageCell outgoingImage;
 
-    @FXML
-    private ImageView imageView;
+    public MessageCustomCellController() {
+        incomingMessage = loadMessageCell("../Views/incoming_message_custom_cell_view.fxml");
+        outgoingMessage = loadMessageCell("../Views/outgoing_message_custom_cell_view.fxml");
+        incomingImage = loadImageCell("../Views/incoming_image_custom_cell_view.fxml");
+        outgoingImage = loadImageCell("../Views/outgoing_image_custom_cell_view.fxml");
+    }
 
-    @FXML
-    private Label messageLabel;
+    private MessageCell loadMessageCell(String resource) {
+        MessageCell cell = new MessageCell();
+        cell.loader = new FXMLLoader(getClass().getResource(resource));
+        cell.loader.setController(cell);
+        try {
+            cell.loader.load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return cell;
+    }
 
-    @FXML
-    private Label messageTimeLabel;
+    private ImageCell loadImageCell(String resource) {
+        ImageCell cell = new ImageCell();
+        cell.loader = new FXMLLoader(getClass().getResource(resource));
+        cell.loader.setController(cell);
+        try {
+            cell.loader.load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return cell;
+    }
+
+    private static class MessageCell {
+        FXMLLoader loader;
+        @FXML
+        GridPane root;
+        @FXML
+        Label messageLabel;
+        @FXML
+        Label messageTimeLabel;
+    }
+
+    private static class ImageCell {
+        FXMLLoader loader;
+        @FXML
+        GridPane root;
+        @FXML
+        ImageView imageView;
+        @FXML
+        Label messageTimeLabel;
+    }
 
     @Override
     protected void updateItem(MessageViewModel item, boolean empty) {
         super.updateItem(item, empty);
-        FXMLLoader fxmlLoader;
         if (empty || item == null) {
             setText(null);
             setGraphic(null);
-        } else {
-            if (item.isOutgoing) {
-                if (item.isImage) {
-                    fxmlLoader = new FXMLLoader(getClass().getResource("../Views/outgoing_image_custom_cell_view.fxml"));
-                } else {
-                    fxmlLoader = new FXMLLoader(getClass().getResource("../Views/outgoing_message_custom_cell_view.fxml"));
-                }
+        } else if (item.isOutgoing) {
+            if (item.isImage) {
+                outgoingImage.messageTimeLabel.setText(item.getTime());
+                outgoingImage.imageView.setImage(item.getImage());
+                setGraphic(outgoingImage.root);
             } else {
-                if (item.isImage) {
-                    fxmlLoader = new FXMLLoader(getClass().getResource("../Views/incoming_image_custom_cell_view.fxml"));
-                } else {
-                    fxmlLoader = new FXMLLoader(getClass().getResource("../Views/incoming_message_custom_cell_view.fxml"));
-                }
+                outgoingMessage.messageTimeLabel.setText(item.getTime());
+                outgoingMessage.messageLabel.setText(item.getMessage());
+                setGraphic(outgoingMessage.root);
             }
-            fxmlLoader.setController(this);
-            try {
-                fxmlLoader.load();
-            } catch (IOException e) {
-                e.printStackTrace();
+        } else {
+            if (item.isImage) {
+                incomingImage.messageTimeLabel.setText(item.getTime());
+                incomingImage.imageView.setImage(item.getImage());
+                setGraphic(incomingImage.root);
+            } else {
+                incomingMessage.messageTimeLabel.setText(item.getTime());
+                incomingMessage.messageLabel.setText(item.getMessage());
+                setGraphic(incomingMessage.root);
             }
-            messageTimeLabel.setText(item.getTime());
-            if (item.isImage) imageView.setImage(item.getImage());
-            else messageLabel.setText(item.getMessage());
-            setGraphic(root);
         }
     }
 }
+

--- a/src/Controllers/UserCustomCellController.java
+++ b/src/Controllers/UserCustomCellController.java
@@ -34,6 +34,19 @@ public class UserCustomCellController extends ListCell<UserViewModel> {
     @FXML
     private StackPane notificationPanel;
 
+    private final FXMLLoader fxmlLoader;
+    private final GridPane rootNode;
+
+    public UserCustomCellController() {
+        fxmlLoader = new FXMLLoader(getClass().getResource("../Views/user_custom_cell_view.fxml"));
+        fxmlLoader.setController(this);
+        try {
+            rootNode = fxmlLoader.load();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     protected void updateItem(UserViewModel item, boolean empty) {
         super.updateItem(item, empty);
@@ -41,21 +54,16 @@ public class UserCustomCellController extends ListCell<UserViewModel> {
             setText(null);
             setGraphic(null);
         } else {
-            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("../Views/user_custom_cell_view.fxml"));
-            fxmlLoader.setController(this);
-            try {
-                fxmlLoader.load();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
             userNameLabel.setText(String.valueOf(item.getUserName()));
             lastMessageLabel.setText(String.valueOf(item.getLastMessage()));
             messageTimeLabel.textProperty().bind(item.time);
             if (!item.getNotificationsNumber().matches("0")) {
                 nombreMessageLabel.textProperty().bind(item.notificationsNumberProperty());
                 if (!notificationPanel.isVisible()) notificationPanel.setVisible(true);
+            } else {
+                notificationPanel.setVisible(false);
             }
-            setGraphic(root);
+            setGraphic(rootNode);
         }
     }
 }

--- a/test/Controllers/MessageCustomCellControllerTest.java
+++ b/test/Controllers/MessageCustomCellControllerTest.java
@@ -1,0 +1,21 @@
+package Controllers;
+
+import Models.MessageViewModel;
+import javafx.embed.swing.JFXPanel;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MessageCustomCellControllerTest {
+    @Test
+    public void reuseLoadedNodeOnUpdate() {
+        new JFXPanel();
+        MessageCustomCellController cell = new MessageCustomCellController();
+        MessageViewModel m1 = new MessageViewModel("Hi", "10:00", true, false, null);
+        MessageViewModel m2 = new MessageViewModel("Hello", "10:01", true, false, null);
+        cell.updateItem(m1, false);
+        Object first = cell.getGraphic();
+        cell.updateItem(m2, false);
+        Object second = cell.getGraphic();
+        assertSame(first, second);
+    }
+}

--- a/test/Controllers/UserCustomCellControllerTest.java
+++ b/test/Controllers/UserCustomCellControllerTest.java
@@ -1,0 +1,21 @@
+package Controllers;
+
+import Models.UserViewModel;
+import javafx.embed.swing.JFXPanel;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserCustomCellControllerTest {
+    @Test
+    public void reuseLoadedNodeOnUpdate() {
+        new JFXPanel();
+        UserCustomCellController cell = new UserCustomCellController();
+        UserViewModel u1 = new UserViewModel("A", "m1", "10:00", "0", null);
+        UserViewModel u2 = new UserViewModel("B", "m2", "10:01", "0", null);
+        cell.updateItem(u1, false);
+        Object first = cell.getGraphic();
+        cell.updateItem(u2, false);
+        Object second = cell.getGraphic();
+        assertSame(first, second);
+    }
+}


### PR DESCRIPTION
## Summary
- Preload and cache all message and image cell FXML variants, reusing them in MessageCustomCellController
- Load user cell FXML once in constructor and reuse nodes on updates
- Add tests to verify list cells reuse previously loaded graphics

## Testing
- `java -Djavafx.platform=Monocle -Dprism.order=sw -Dprism.text=t2k --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.swing -jar junit-platform-console-standalone.jar --class-path out --scan-class-path` *(failed: Error initializing QuantumRenderer: no suitable pipeline found)*

------
https://chatgpt.com/codex/tasks/task_e_689683edd614832981e2917c357c35da