### PR TITLE
Validate username before sign up

### DIFF
--- a/src/Controllers/LogInController.java
+++ b/src/Controllers/LogInController.java
@@ -7,6 +7,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.input.MouseEvent;
 
 import java.io.IOException;
@@ -36,8 +37,21 @@ public class LogInController implements Initializable {
 
     @FXML
     void signUp(ActionEvent event) {
+        String enteredName = userNameTextField.getText();
+        if (enteredName == null) {
+            enteredName = "";
+        }
+
+        String trimmedName = enteredName.trim();
+        if (trimmedName.isEmpty() || !enteredName.equals(trimmedName)) {
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setContentText("Please enter a valid username.");
+            alert.show();
+            return;
+        }
+
         try {
-            userName = userNameTextField.getText();
+            userName = trimmedName;
             Parent root = FXMLLoader.load(getClass().getResource("../Views/home_view.fxml"));
             Main.stage.setScene(new Scene(root));
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- ensure sign-up requires a non-empty, trimmed username
- store the cleaned username for later use

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `mvn -q test` *(fails: Missing POM)*
- `mvn -q checkstyle:check` *(fails: No plugin found for prefix 'checkstyle')*

------
https://chatgpt.com/codex/tasks/task_e_689684001fb8832992f1cb92365eac3b