### PR TITLE
refactor: move inline styles to css

### DIFF
--- a/src/Views/home_view.fxml
+++ b/src/Views/home_view.fxml
@@ -16,7 +16,10 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<GridPane alignment="center" style="-fx-background-color: #fff;" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.HomeController">
+<GridPane alignment="center" styleClass="background-white" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.HomeController">
+    <stylesheets>
+        <URL value="@../resources/css/colors.css" />
+    </stylesheets>
     <columnConstraints>
         <ColumnConstraints minWidth="10.0" percentWidth="100.0" />
     </columnConstraints>
@@ -25,7 +28,7 @@
         <RowConstraints minHeight="10.0" percentHeight="95.0" vgrow="ALWAYS" />
     </rowConstraints>
     <children>
-      <GridPane style="-fx-background-color: #1F2936;">
+      <GridPane styleClass="background-main">
          <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
          </columnConstraints>
@@ -79,7 +82,7 @@
                         <RowConstraints minHeight="10.0" percentHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                     </rowConstraints>
                     <children>
-                        <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" style="-fx-background-color: #17212B;">
+                        <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" styleClass="background-dark">
                             <children>
                         <VBox alignment="CENTER_LEFT" spacing="5.0" HBox.hgrow="ALWAYS">
                            <HBox.margin>
@@ -120,9 +123,9 @@
                                 <Insets left="20.0" />
                             </padding>
                         </HBox>
-                        <VBox prefHeight="200.0" prefWidth="100.0" style="-fx-background-color: #0E1621;" GridPane.rowIndex="1">
+                        <VBox prefHeight="200.0" prefWidth="100.0" styleClass="background-darker" GridPane.rowIndex="1">
                      <children>
-                        <ListView fx:id="messagesListView" style="-fx-background-color: #0E1621;" VBox.vgrow="ALWAYS">
+                        <ListView fx:id="messagesListView" styleClass="background-darker" VBox.vgrow="ALWAYS">
                            <VBox.margin>
                               <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                            </VBox.margin>
@@ -132,14 +135,14 @@
                            </stylesheets>
                         </ListView>
                      </children></VBox>
-                        <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" style="-fx-background-color: #17212B;" GridPane.rowIndex="2">
+                        <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="200.0" spacing="10.0" styleClass="background-dark" GridPane.rowIndex="2">
                      <children>
                         <ImageView fitHeight="30.0" fitWidth="30.0" onMouseClicked="#attachFile" pickOnBounds="true" preserveRatio="true">
                            <image>
                               <Image url="@../resources/img/attach.png" />
                            </image>
                         </ImageView>
-                        <TextArea fx:id="messageField" onKeyPressed="#messageFieldKeyPressed" prefHeight="100.0" prefWidth="784.0" promptText="Type a message..." wrapText="true" style="-fx-background-color: transparent;" stylesheets="@../resources/css/textField.css" HBox.hgrow="ALWAYS" />
+                        <TextArea fx:id="messageField" onKeyPressed="#messageFieldKeyPressed" prefHeight="100.0" prefWidth="784.0" promptText="Type a message..." wrapText="true" styleClass="transparent-background" stylesheets="@../resources/css/textField.css" HBox.hgrow="ALWAYS" />
                         <ImageView fitHeight="35.0" fitWidth="35.0" onMouseClicked="#smileyButtonClicked" pickOnBounds="true" preserveRatio="true">
                            <image>
                               <Image url="@../resources/img/smile.png" />
@@ -156,7 +159,7 @@
                      </padding></HBox>
                     </children>
                 </GridPane>
-                <GridPane style="-fx-background-color: #17212B;">
+                <GridPane styleClass="background-dark">
                     <columnConstraints>
                         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="100.0" />
                     </columnConstraints>
@@ -168,20 +171,20 @@
                         <DropShadow color="#000000ab" height="0.0" radius="2.4175" spread="0.2" width="11.67" />
                     </effect>
                     <children>
-                        <HBox alignment="CENTER_LEFT" spacing="20.0" style="-fx-background-color: #17212B;">
+                        <HBox alignment="CENTER_LEFT" spacing="20.0" styleClass="background-dark">
                             <children>
                                 <ImageView fitHeight="40.0" fitWidth="40.0" onMouseClicked="#slideMenuClicked" pickOnBounds="true" preserveRatio="true">
                                     <image>
                                         <Image url="@../resources/img/Liste.png" />
                                     </image>
                                 </ImageView>
-                                <TextField promptText="Search" style="-fx-background-color: #242F3D;" HBox.hgrow="ALWAYS" />
+                                <TextField promptText="Search" styleClass="background-search" HBox.hgrow="ALWAYS" />
                             </children>
                             <padding>
                                 <Insets left="20.0" right="20.0" />
                             </padding>
                         </HBox>
-                  <ListView fx:id="usersListView" style="-fx-background-color: #17212B;" GridPane.rowIndex="1">
+                  <ListView fx:id="usersListView" styleClass="background-dark" GridPane.rowIndex="1">
                      <stylesheets>
                         <URL value="@../resources/css/usersListViewCss.css" />
                         <URL value="@../resources/css/cellViewCss.css" />

--- a/src/Views/incoming_image_custom_cell_view.fxml
+++ b/src/Views/incoming_image_custom_cell_view.fxml
@@ -10,6 +10,9 @@
 <?import javafx.scene.text.Font?>
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+   <stylesheets>
+      <URL value="@../resources/css/colors.css" />
+   </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
@@ -18,7 +21,7 @@
       <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
    </rowConstraints>
    <children>
-      <HBox alignment="BOTTOM_RIGHT" spacing="10.0" style="-fx-background-radius: 10px; -fx-background-color: #182533;">
+      <HBox alignment="BOTTOM_RIGHT" spacing="10.0" styleClass="bubble-incoming">
          <children>
             <ImageView fx:id="imageView" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" />
             <Label fx:id="messageTimeLabel" alignment="CENTER" text="10:00" textAlignment="CENTER" textFill="#92a3af">

--- a/src/Views/incoming_message_custom_cell_view.fxml
+++ b/src/Views/incoming_message_custom_cell_view.fxml
@@ -10,6 +10,9 @@
 <?import javafx.scene.text.Font?>
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+   <stylesheets>
+      <URL value="@../resources/css/colors.css" />
+   </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
@@ -18,7 +21,7 @@
       <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
    </rowConstraints>
    <children>
-      <HBox spacing="10.0" style="-fx-background-radius: 10px; -fx-background-color: #182533;">
+      <HBox spacing="10.0" styleClass="bubble-incoming">
          <children>
             <Label fx:id="messageLabel" alignment="TOP_LEFT" maxHeight="-Infinity" maxWidth="400.0" text="MessageMessage" textFill="WHITE" wrapText="true">
                <font>

--- a/src/Views/login_view.fxml
+++ b/src/Views/login_view.fxml
@@ -14,7 +14,11 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<GridPane alignment="center" stylesheets="@../resources/css/imageBackground.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.LogInController">
+<GridPane alignment="center" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.LogInController">
+   <stylesheets>
+      <URL value="@../resources/css/imageBackground.css" />
+      <URL value="@../resources/css/colors.css" />
+   </stylesheets>
    <columnConstraints>
       <ColumnConstraints minWidth="10.0" percentWidth="100.0" />
    </columnConstraints>
@@ -172,7 +176,7 @@
                               <Font size="22.0" />
                            </font>
                         </JFXTextField>
-                        <JFXButton onAction="#signUp" prefHeight="54.0" prefWidth="500.0" ripplerFill="WHITE" style="-fx-background-color: #202D3A;" text="Sign up" textFill="WHITE">
+                        <JFXButton onAction="#signUp" prefHeight="54.0" prefWidth="500.0" ripplerFill="WHITE" styleClass="button-dark" text="Sign up" textFill="WHITE">
                            <font>
                               <Font name="Calibri" size="25.0" />
                            </font>

--- a/src/Views/outgoing_image_custom_cell_view.fxml
+++ b/src/Views/outgoing_image_custom_cell_view.fxml
@@ -10,6 +10,9 @@
 <?import javafx.scene.text.Font?>
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+   <stylesheets>
+      <URL value="@../resources/css/colors.css" />
+   </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
@@ -18,7 +21,7 @@
       <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
    </rowConstraints>
    <children>
-      <HBox alignment="BOTTOM_RIGHT" spacing="10.0" style="-fx-background-radius: 10px; -fx-background-color: #2B5278;" GridPane.columnIndex="1">
+      <HBox alignment="BOTTOM_RIGHT" spacing="10.0" styleClass="bubble-outgoing" GridPane.columnIndex="1">
          <children>
             <ImageView fx:id="imageView" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" />
             <Label fx:id="messageTimeLabel" alignment="CENTER" text="10:00" textAlignment="CENTER" textFill="#92a3af">

--- a/src/Views/outgoing_message_custom_cell_view.fxml
+++ b/src/Views/outgoing_message_custom_cell_view.fxml
@@ -9,6 +9,9 @@
 <?import javafx.scene.text.Font?>
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+   <stylesheets>
+      <URL value="@../resources/css/colors.css" />
+   </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
@@ -17,7 +20,7 @@
       <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
    </rowConstraints>
    <children>
-      <HBox spacing="10.0" style="-fx-background-radius: 10px; -fx-background-color: #2B5278;" GridPane.columnIndex="1">
+      <HBox spacing="10.0" styleClass="bubble-outgoing" GridPane.columnIndex="1">
          <children>
             <Label fx:id="messageLabel" alignment="TOP_LEFT" maxHeight="-Infinity" maxWidth="400.0" text="Meesage" textFill="WHITE" wrapText="true">
                <font>

--- a/src/resources/css/colors.css
+++ b/src/resources/css/colors.css
@@ -1,0 +1,37 @@
+.background-white {
+    -fx-background-color: #fff;
+}
+
+.background-main {
+    -fx-background-color: #1F2936;
+}
+
+.background-dark {
+    -fx-background-color: #17212B;
+}
+
+.background-darker {
+    -fx-background-color: #0E1621;
+}
+
+.background-search {
+    -fx-background-color: #242F3D;
+}
+
+.button-dark {
+    -fx-background-color: #202D3A;
+}
+
+.bubble-outgoing {
+    -fx-background-radius: 10px;
+    -fx-background-color: #2B5278;
+}
+
+.bubble-incoming {
+    -fx-background-radius: 10px;
+    -fx-background-color: #182533;
+}
+
+.transparent-background {
+    -fx-background-color: transparent;
+}


### PR DESCRIPTION
## Summary
- consolidate repeated background and bubble styling into `colors.css`
- replace inline styles in FXML files with reusable CSS classes
- link views to shared stylesheet instead of embedding properties

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `gradle test` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68968428c50c8329b40ee316cc0fea52