### PR TITLE
Avoid memory leaks in custom cells

### DIFF
--- a/src/Controllers/MessageCustomCellController.java
+++ b/src/Controllers/MessageCustomCellController.java
@@ -26,10 +26,10 @@ public class MessageCustomCellController extends ListCell<MessageViewModel> {
 
     private MessageCell loadMessageCell(String resource) {
         MessageCell cell = new MessageCell();
-        cell.loader = new FXMLLoader(getClass().getResource(resource));
-        cell.loader.setController(cell);
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(resource));
+        loader.setController(cell);
         try {
-            cell.loader.load();
+            loader.load();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -38,10 +38,10 @@ public class MessageCustomCellController extends ListCell<MessageViewModel> {
 
     private ImageCell loadImageCell(String resource) {
         ImageCell cell = new ImageCell();
-        cell.loader = new FXMLLoader(getClass().getResource(resource));
-        cell.loader.setController(cell);
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(resource));
+        loader.setController(cell);
         try {
-            cell.loader.load();
+            loader.load();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -49,7 +49,6 @@ public class MessageCustomCellController extends ListCell<MessageViewModel> {
     }
 
     private static class MessageCell {
-        FXMLLoader loader;
         @FXML
         GridPane root;
         @FXML
@@ -59,7 +58,6 @@ public class MessageCustomCellController extends ListCell<MessageViewModel> {
     }
 
     private static class ImageCell {
-        FXMLLoader loader;
         @FXML
         GridPane root;
         @FXML

--- a/src/Controllers/UserCustomCellController.java
+++ b/src/Controllers/UserCustomCellController.java
@@ -50,13 +50,15 @@ public class UserCustomCellController extends ListCell<UserViewModel> {
     @Override
     protected void updateItem(UserViewModel item, boolean empty) {
         super.updateItem(item, empty);
+        messageTimeLabel.textProperty().unbind();
+        nombreMessageLabel.textProperty().unbind();
         if (empty || item == null) {
             setText(null);
             setGraphic(null);
         } else {
             userNameLabel.setText(String.valueOf(item.getUserName()));
             lastMessageLabel.setText(String.valueOf(item.getLastMessage()));
-            messageTimeLabel.textProperty().bind(item.time);
+            messageTimeLabel.textProperty().bind(item.timeProperty());
             if (!item.getNotificationsNumber().equals("0")) {
                 nombreMessageLabel.textProperty().bind(item.notificationsNumberProperty());
                 if (!notificationPanel.isVisible()) notificationPanel.setVisible(true);


### PR DESCRIPTION
## Summary
- Unbind previous property listeners before rebinding in `UserCustomCellController` to prevent leaks when cells are reused.
- Load FXML resources in constructors without keeping loader references in `MessageCustomCellController`.

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `gradle test` *(fails: Directory '/workspace/amos-desktop-java' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68969eb4e6488329bcd4a78af8a73d15