### PR TITLE
Use executor service for network retries and timeouts

### DIFF
--- a/src/ToolBox/NetworkConnection.java
+++ b/src/ToolBox/NetworkConnection.java
@@ -2,74 +2,138 @@ package ToolBox;
 
 import javafx.scene.image.Image;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.function.Consumer;
 
 public class NetworkConnection {
-    private ConnectionThread connection = new ConnectionThread();
+    private static final Logger logger = Logger.getLogger(NetworkConnection.class.getName());
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final ConnectionHandler connection = new ConnectionHandler();
     public Consumer<Serializable> receiveCallBack;
+    public Consumer<Exception> errorCallBack;
     public String ip;
     public boolean isServer;
     public int port;
+    public int timeout;
+    public int maxRetries;
+    private volatile boolean running = false;
 
+    public NetworkConnection(Consumer<Serializable> receiveCallBack,
+                             Consumer<Exception> errorCallBack,
+                             String ip, boolean isServer, int port) {
+        this(receiveCallBack, errorCallBack, ip, isServer, port, 5000, 3);
+    }
 
-    public NetworkConnection(Consumer<Serializable> receiveCallBack, String ip, boolean isServer, int port) {
+    public NetworkConnection(Consumer<Serializable> receiveCallBack,
+                             Consumer<Exception> errorCallBack,
+                             String ip, boolean isServer, int port,
+                             int timeout, int maxRetries) {
         this.receiveCallBack = receiveCallBack;
+        this.errorCallBack = errorCallBack;
         this.ip = ip;
         this.isServer = isServer;
         this.port = port;
+        this.timeout = timeout;
+        this.maxRetries = maxRetries;
     }
 
     public void openConnection() {
-        connection.start();
+        running = true;
+        executor.submit(connection);
     }
 
-    public void sendData(Serializable data) throws IOException {
-        connection.outputStream.writeObject(data);
+    public void sendData(Serializable data) {
+        executor.submit(() -> {
+            try {
+                synchronized (connection.outputStream) {
+                    connection.outputStream.writeObject(data);
+                }
+            } catch (IOException e) {
+                handleException(e);
+            }
+        });
     }
 
-    public void sendImage(Image image) throws IOException {
-        connection.outputStream.defaultWriteObject();
-        connection.outputStream.writeObject(image);
+    public void sendImage(Image image) {
+        executor.submit(() -> {
+            try {
+                synchronized (connection.outputStream) {
+                    connection.outputStream.defaultWriteObject();
+                    connection.outputStream.writeObject(image);
+                }
+            } catch (IOException e) {
+                handleException(e);
+            }
+        });
     }
 
-    public void closeConnection() throws IOException {
-        connection.socket.close();
+    public void closeConnection() {
+        running = false;
+        try {
+            if (connection.socket != null && !connection.socket.isClosed()) {
+                connection.socket.close();
+            }
+        } catch (IOException e) {
+            handleException(e);
+        }
+        executor.shutdownNow();
     }
 
-    private class ConnectionThread extends Thread {
+    private void handleException(Exception e) {
+        logger.log(Level.WARNING, "Network error", e);
+        if (errorCallBack != null) {
+            errorCallBack.accept(e);
+        }
+    }
+
+    private class ConnectionHandler implements Runnable {
         private Socket socket;
         private ObjectOutputStream outputStream;
 
         @Override
         public void run() {
-            super.run();
-            try {
-                ServerSocket server = isServer ? new ServerSocket(port) : null;
-                Socket socket = isServer ? server.accept() : new Socket(ip, port);
-                ObjectOutputStream outputStream = new ObjectOutputStream(socket.getOutputStream());
-                ObjectInputStream inputStream = new ObjectInputStream(socket.getInputStream());
-                socket.setTcpNoDelay(true);
-                this.socket = socket;
-                this.outputStream = outputStream;
+            int attempts = 0;
+            while (running && attempts <= maxRetries) {
+                try {
+                    if (isServer) {
+                        try (ServerSocket server = new ServerSocket(port)) {
+                            server.setSoTimeout(timeout);
+                            socket = server.accept();
+                        }
+                    } else {
+                        socket = new Socket();
+                        socket.connect(new InetSocketAddress(ip, port), timeout);
+                    }
+                    socket.setSoTimeout(timeout);
+                    outputStream = new ObjectOutputStream(socket.getOutputStream());
+                    ObjectInputStream inputStream = new ObjectInputStream(socket.getInputStream());
 
-                while (true) {
-                    Serializable data = (Serializable) inputStream.readObject();
-                    receiveCallBack.accept(data);
-
+                    while (running) {
+                        try {
+                            Serializable data = (Serializable) inputStream.readObject();
+                            receiveCallBack.accept(data);
+                        } catch (SocketTimeoutException e) {
+                            // allow loop to check running flag
+                        }
+                    }
+                    break;
+                } catch (IOException | ClassNotFoundException e) {
+                    handleException(e);
+                    attempts++;
                 }
-
-            } catch (IOException | ClassNotFoundException e) {
-                e.printStackTrace();
             }
         }
     }
-
 }


### PR DESCRIPTION
## Summary
- Refactor network layer to run on an ExecutorService thread pool with connection retries, timeouts and graceful shutdown
- Route network exceptions through callbacks and logging for UI handling
- Update HomeController to display connection errors and simplify message sending/closing

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM)*
- `gradle test` *(fails: Directory '/workspace/amos-desktop-java' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68969ec884a483298aa87fe5d23cfd4a