### PR TITLE
Add basic authentication and username validation

### DIFF
--- a/src/Controllers/LogInController.java
+++ b/src/Controllers/LogInController.java
@@ -10,6 +10,9 @@ import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.input.MouseEvent;
 
+import java.util.regex.Pattern;
+import ToolBox.AuthService;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -17,8 +20,11 @@ import java.util.ResourceBundle;
 public class LogInController implements Initializable {
 
     public static String userName;
+    private static final Pattern NAME_PATTERN = Pattern.compile("^[A-Za-z0-9_]{3,15}$");
     @FXML
     private JFXTextField userNameTextField;
+    @FXML
+    private JFXTextField phoneNumberTextField;
 
 
     @Override
@@ -43,9 +49,20 @@ public class LogInController implements Initializable {
         }
 
         String trimmedName = enteredName.trim();
-        if (trimmedName.isEmpty() || !enteredName.equals(trimmedName)) {
+        if (!NAME_PATTERN.matcher(trimmedName).matches()) {
             Alert alert = new Alert(Alert.AlertType.ERROR);
             alert.setContentText("Please enter a valid username.");
+            alert.show();
+            return;
+        }
+
+        String phoneNumber = phoneNumberTextField.getText();
+        if (phoneNumber == null) {
+            phoneNumber = "";
+        }
+        if (!AuthService.authenticate(trimmedName, phoneNumber)) {
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setContentText("Authentication failed. Please check your credentials.");
             alert.show();
             return;
         }

--- a/src/ToolBox/AuthService.java
+++ b/src/ToolBox/AuthService.java
@@ -1,0 +1,19 @@
+package ToolBox;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AuthService {
+
+    private static final Map<String, String> USERS = new HashMap<>();
+
+    static {
+        USERS.put("user1", "12345");
+        USERS.put("user2", "54321");
+    }
+
+    public static boolean authenticate(String username, String phoneNumber) {
+        String stored = USERS.get(username);
+        return stored != null && stored.equals(phoneNumber);
+    }
+}

--- a/src/Views/login_view.fxml
+++ b/src/Views/login_view.fxml
@@ -171,7 +171,7 @@
                               <Font size="22.0" />
                            </font>
                         </JFXTextField>
-                        <JFXTextField focusColor="WHITE" promptText="Phone Number" stylesheets="@../resources/css/textField.css" unFocusColor="#d1d3d3">
+                        <JFXTextField fx:id="phoneNumberTextField" focusColor="WHITE" promptText="Phone Number" stylesheets="@../resources/css/textField.css" unFocusColor="#d1d3d3">
                            <font>
                               <Font size="22.0" />
                            </font>

--- a/test/ToolBox/AuthServiceTest.java
+++ b/test/ToolBox/AuthServiceTest.java
@@ -1,0 +1,17 @@
+package ToolBox;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuthServiceTest {
+
+    @Test
+    public void validCredentialsReturnTrue() {
+        assertTrue(AuthService.authenticate("user1", "12345"));
+    }
+
+    @Test
+    public void invalidCredentialsReturnFalse() {
+        assertFalse(AuthService.authenticate("user1", "wrong"));
+    }
+}


### PR DESCRIPTION
## Summary
- validate usernames with regex pattern
- add simple in-memory authentication and error handling
- hook phone number field to controller and add auth unit test

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `gradle test` *(fails: Directory does not contain a Gradle build)*
- `mvn -q checkstyle:check` *(fails: No plugin found for prefix 'checkstyle')*

------
https://chatgpt.com/codex/tasks/task_e_68969edf3ee483299bedc5e80a169c26