### PR TITLE
Load JavaFX resources from classpath

### DIFF
--- a/src/Controllers/HomeController.java
+++ b/src/Controllers/HomeController.java
@@ -33,6 +33,7 @@ import java.util.ResourceBundle;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+import java.util.Objects;
 
 import static ToolBox.Utilities.getCurrentTime;
 
@@ -52,7 +53,7 @@ public class HomeController implements Initializable {
     NetworkConnection connection;
     private ObservableList<UserViewModel> usersList = FXCollections.observableArrayList();
     UserViewModel currentlySelectedUser, localUser;
-    Image userImage = new Image("resources/img/smile.png");
+    Image userImage = new Image(Objects.requireNonNull(getClass().getResource("/resources/img/smile.png")).toExternalForm());
 
     private static final int MAX_MESSAGE_LENGTH = 100000;
     private static final int BATCH_SIZE = 4096;

--- a/src/Controllers/LogInController.java
+++ b/src/Controllers/LogInController.java
@@ -52,7 +52,7 @@ public class LogInController implements Initializable {
 
         try {
             userName = trimmedName;
-            Parent root = FXMLLoader.load(getClass().getResource("../Views/home_view.fxml"));
+            Parent root = FXMLLoader.load(getClass().getResource("/Views/home_view.fxml"));
             Main.stage.setScene(new Scene(root));
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/Controllers/Main.java
+++ b/src/Controllers/Main.java
@@ -11,7 +11,7 @@ public class Main extends Application {
     public static Stage stage;
     @Override
     public void start(Stage primaryStage) throws Exception{
-        Parent root = FXMLLoader.load(getClass().getResource("../Views/login_view.fxml"));
+        Parent root = FXMLLoader.load(getClass().getResource("/Views/login_view.fxml"));
         primaryStage.setScene(new Scene(root, 1280, 720));
         primaryStage.initStyle(StageStyle.UNDECORATED);
         stage = primaryStage;

--- a/src/Controllers/MessageCustomCellController.java
+++ b/src/Controllers/MessageCustomCellController.java
@@ -18,10 +18,10 @@ public class MessageCustomCellController extends ListCell<MessageViewModel> {
     private final ImageCell outgoingImage;
 
     public MessageCustomCellController() {
-        incomingMessage = loadMessageCell("../Views/incoming_message_custom_cell_view.fxml");
-        outgoingMessage = loadMessageCell("../Views/outgoing_message_custom_cell_view.fxml");
-        incomingImage = loadImageCell("../Views/incoming_image_custom_cell_view.fxml");
-        outgoingImage = loadImageCell("../Views/outgoing_image_custom_cell_view.fxml");
+        incomingMessage = loadMessageCell("/Views/incoming_message_custom_cell_view.fxml");
+        outgoingMessage = loadMessageCell("/Views/outgoing_message_custom_cell_view.fxml");
+        incomingImage = loadImageCell("/Views/incoming_image_custom_cell_view.fxml");
+        outgoingImage = loadImageCell("/Views/outgoing_image_custom_cell_view.fxml");
     }
 
     private MessageCell loadMessageCell(String resource) {

--- a/src/Controllers/UserCustomCellController.java
+++ b/src/Controllers/UserCustomCellController.java
@@ -38,7 +38,7 @@ public class UserCustomCellController extends ListCell<UserViewModel> {
     private final GridPane rootNode;
 
     public UserCustomCellController() {
-        fxmlLoader = new FXMLLoader(getClass().getResource("../Views/user_custom_cell_view.fxml"));
+        fxmlLoader = new FXMLLoader(getClass().getResource("/Views/user_custom_cell_view.fxml"));
         fxmlLoader.setController(this);
         try {
             rootNode = fxmlLoader.load();

--- a/src/Views/home_view.fxml
+++ b/src/Views/home_view.fxml
@@ -18,7 +18,7 @@
 
 <GridPane alignment="center" styleClass="background-white" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.HomeController">
     <stylesheets>
-        <URL value="@../resources/css/colors.css" />
+        <URL value="@/resources/css/colors.css" />
     </stylesheets>
     <columnConstraints>
         <ColumnConstraints minWidth="10.0" percentWidth="100.0" />
@@ -40,12 +40,12 @@
                <children>
                   <ImageView fitHeight="25.0" fitWidth="25.0" onMouseClicked="#minimizeApp" pickOnBounds="true" preserveRatio="true">
                      <image>
-                        <Image url="@../resources/img/minimize.png" />
+                        <Image url="@/resources/img/minimize.png" />
                      </image>
                   </ImageView>
                   <ImageView fitHeight="25.0" fitWidth="25.0" onMouseClicked="#closeApp" pickOnBounds="true" preserveRatio="true">
                      <image>
-                        <Image url="@../resources/img/quitButton.png" />
+                        <Image url="@/resources/img/quitButton.png" />
                      </image>
                   </ImageView>
                </children>
@@ -105,12 +105,12 @@
                                     <children>
                                         <ImageView fitHeight="40.0" fitWidth="40.0" onMouseClicked="#searchChatRoom" pickOnBounds="true" preserveRatio="true">
                                             <image>
-                                                <Image url="@../resources/img/search.png" />
+                                                <Image url="@/resources/img/search.png" />
                                             </image>
                                         </ImageView>
                                         <ImageView fitHeight="40.0" fitWidth="40.0" onMouseClicked="#settingsButtonClicked" pickOnBounds="true" preserveRatio="true">
                                             <image>
-                                                <Image url="@../resources/img/settings.png" />
+                                                <Image url="@/resources/img/settings.png" />
                                             </image>
                                         </ImageView>
                                     </children>
@@ -130,8 +130,8 @@
                               <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                            </VBox.margin>
                            <stylesheets>
-                              <URL value="@../resources/css/messageCellViewCss.css" />
-                              <URL value="@../resources/css/usersListViewCss.css" />
+                              <URL value="@/resources/css/messageCellViewCss.css" />
+                              <URL value="@/resources/css/usersListViewCss.css" />
                            </stylesheets>
                         </ListView>
                      </children></VBox>
@@ -139,18 +139,18 @@
                      <children>
                         <ImageView fitHeight="30.0" fitWidth="30.0" onMouseClicked="#attachFile" pickOnBounds="true" preserveRatio="true">
                            <image>
-                              <Image url="@../resources/img/attach.png" />
+                              <Image url="@/resources/img/attach.png" />
                            </image>
                         </ImageView>
-                        <TextArea fx:id="messageField" onKeyPressed="#messageFieldKeyPressed" prefHeight="100.0" prefWidth="784.0" promptText="Type a message..." wrapText="true" styleClass="transparent-background" stylesheets="@../resources/css/textField.css" HBox.hgrow="ALWAYS" />
+                        <TextArea fx:id="messageField" onKeyPressed="#messageFieldKeyPressed" prefHeight="100.0" prefWidth="784.0" promptText="Type a message..." wrapText="true" styleClass="transparent-background" stylesheets="@/resources/css/textField.css" HBox.hgrow="ALWAYS" />
                         <ImageView fitHeight="35.0" fitWidth="35.0" onMouseClicked="#smileyButtonClicked" pickOnBounds="true" preserveRatio="true">
                            <image>
-                              <Image url="@../resources/img/smile.png" />
+                              <Image url="@/resources/img/smile.png" />
                            </image>
                         </ImageView>
                         <ImageView fitHeight="35.0" fitWidth="35.0" onMouseClicked="#vocalMessageClicked" pickOnBounds="true" preserveRatio="true">
                            <image>
-                              <Image url="@../resources/img/mic.png" />
+                              <Image url="@/resources/img/mic.png" />
                            </image>
                         </ImageView>
                      </children>
@@ -175,7 +175,7 @@
                             <children>
                                 <ImageView fitHeight="40.0" fitWidth="40.0" onMouseClicked="#slideMenuClicked" pickOnBounds="true" preserveRatio="true">
                                     <image>
-                                        <Image url="@../resources/img/Liste.png" />
+                                        <Image url="@/resources/img/Liste.png" />
                                     </image>
                                 </ImageView>
                                 <TextField promptText="Search" styleClass="background-search" HBox.hgrow="ALWAYS" />
@@ -186,8 +186,8 @@
                         </HBox>
                   <ListView fx:id="usersListView" styleClass="background-dark" GridPane.rowIndex="1">
                      <stylesheets>
-                        <URL value="@../resources/css/usersListViewCss.css" />
-                        <URL value="@../resources/css/cellViewCss.css" />
+                        <URL value="@/resources/css/usersListViewCss.css" />
+                        <URL value="@/resources/css/cellViewCss.css" />
                      </stylesheets>
                   </ListView>
                     </children>

--- a/src/Views/incoming_image_custom_cell_view.fxml
+++ b/src/Views/incoming_image_custom_cell_view.fxml
@@ -11,7 +11,7 @@
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <stylesheets>
-      <URL value="@../resources/css/colors.css" />
+      <URL value="@/resources/css/colors.css" />
    </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />

--- a/src/Views/incoming_message_custom_cell_view.fxml
+++ b/src/Views/incoming_message_custom_cell_view.fxml
@@ -11,7 +11,7 @@
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <stylesheets>
-      <URL value="@../resources/css/colors.css" />
+      <URL value="@/resources/css/colors.css" />
    </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />

--- a/src/Views/login_view.fxml
+++ b/src/Views/login_view.fxml
@@ -16,8 +16,8 @@
 
 <GridPane alignment="center" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Controllers.LogInController">
    <stylesheets>
-      <URL value="@../resources/css/imageBackground.css" />
-      <URL value="@../resources/css/colors.css" />
+      <URL value="@/resources/css/imageBackground.css" />
+      <URL value="@/resources/css/colors.css" />
    </stylesheets>
    <columnConstraints>
       <ColumnConstraints minWidth="10.0" percentWidth="100.0" />
@@ -39,12 +39,12 @@
                <children>
                   <ImageView fitHeight="25.0" fitWidth="25.0" onMouseClicked="#minimizeApp" pickOnBounds="true" preserveRatio="true">
                      <image>
-                        <Image url="@../resources/img/minimize.png" />
+                        <Image url="@/resources/img/minimize.png" />
                      </image>
                   </ImageView>
                   <ImageView fitHeight="25.0" fitWidth="25.0" onMouseClicked="#closeApp" pickOnBounds="true" preserveRatio="true">
                      <image>
-                        <Image url="@../resources/img/quitButton.png" />
+                        <Image url="@/resources/img/quitButton.png" />
                      </image>
                   </ImageView>
                </children>
@@ -68,7 +68,7 @@
                <children>
                   <ImageView fitHeight="75.0" fitWidth="75.0" pickOnBounds="true" preserveRatio="true">
                      <image>
-                        <Image url="@../resources/img/email.png" />
+                        <Image url="@/resources/img/email.png" />
                      </image>
                   </ImageView>
                   <Label text="JetGram" textFill="WHITE">
@@ -166,12 +166,12 @@
                               <Insets bottom="30.0" />
                            </VBox.margin>
                         </Label>
-                        <JFXTextField fx:id="userNameTextField" focusColor="WHITE" promptText="User name" stylesheets="@../resources/css/textField.css" unFocusColor="#d1d3d3">
+                        <JFXTextField fx:id="userNameTextField" focusColor="WHITE" promptText="User name" stylesheets="@/resources/css/textField.css" unFocusColor="#d1d3d3">
                            <font>
                               <Font size="22.0" />
                            </font>
                         </JFXTextField>
-                        <JFXTextField focusColor="WHITE" promptText="Phone Number" stylesheets="@../resources/css/textField.css" unFocusColor="#d1d3d3">
+                        <JFXTextField focusColor="WHITE" promptText="Phone Number" stylesheets="@/resources/css/textField.css" unFocusColor="#d1d3d3">
                            <font>
                               <Font size="22.0" />
                            </font>

--- a/src/Views/outgoing_image_custom_cell_view.fxml
+++ b/src/Views/outgoing_image_custom_cell_view.fxml
@@ -11,7 +11,7 @@
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <stylesheets>
-      <URL value="@../resources/css/colors.css" />
+      <URL value="@/resources/css/colors.css" />
    </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />

--- a/src/Views/outgoing_message_custom_cell_view.fxml
+++ b/src/Views/outgoing_message_custom_cell_view.fxml
@@ -10,7 +10,7 @@
 
 <GridPane fx:id="root" alignment="CENTER" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <stylesheets>
-      <URL value="@../resources/css/colors.css" />
+      <URL value="@/resources/css/colors.css" />
    </stylesheets>
    <columnConstraints>
       <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />

--- a/src/Views/user_custom_cell_view.fxml
+++ b/src/Views/user_custom_cell_view.fxml
@@ -26,7 +26,7 @@
          <children>
             <ImageView fx:id="avatarImage" fitHeight="50.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" VBox.vgrow="ALWAYS">
                <image>
-                  <Image url="@../resources/img/email.png" />
+                  <Image url="@/resources/img/email.png" />
                </image>
             </ImageView>
          </children>


### PR DESCRIPTION
## Summary
- Replace hard-coded resource paths with `getResource` to ensure lookup via the classpath.
- Load all FXML files using absolute classpath locations for consistent access in and out of IDEs.
- Update FXML resource references to use classpath-based URLs, ensuring packaging into the JAR.

## Testing
- `mvn -q test` *(fails: no POM in directory)*
- `gradle -q test` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68969ee6c2808329b9e1b8d8bae4ba1b