### PR TITLE
Refactor stage handling to use shared context

### DIFF
--- a/src/Controllers/AppContext.java
+++ b/src/Controllers/AppContext.java
@@ -1,0 +1,24 @@
+package Controllers;
+
+import javafx.stage.Stage;
+
+public class AppContext {
+    private final Stage stage;
+    private String userName;
+
+    public AppContext(Stage stage) {
+        this.stage = stage;
+    }
+
+    public Stage getStage() {
+        return stage;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+}

--- a/src/Controllers/ContextAware.java
+++ b/src/Controllers/ContextAware.java
@@ -1,0 +1,5 @@
+package Controllers;
+
+public interface ContextAware {
+    void setContext(AppContext context);
+}

--- a/src/Controllers/HomeController.java
+++ b/src/Controllers/HomeController.java
@@ -36,7 +36,14 @@ import java.util.List;
 
 import static ToolBox.Utilities.getCurrentTime;
 
-public class HomeController implements Initializable {
+public class HomeController implements Initializable, ContextAware {
+
+    private AppContext context;
+
+    @Override
+    public void setContext(AppContext context) {
+        this.context = context;
+    }
 
     @FXML
     private Label userNameLabel;
@@ -76,7 +83,7 @@ public class HomeController implements Initializable {
                     , new UserViewModel("Oscar", "I agree, when?", getCurrentTime(), 2 + "", userImage));
         }
 
-        localUser = new UserViewModel(LogInController.userName, "message", getCurrentTime(), 0 + "", userImage);
+        localUser = new UserViewModel(context.getUserName(), "message", getCurrentTime(), 0 + "", userImage);
         userNameLabel.setText(localUser.getUserName());
 
         usersListView.setItems(usersList);
@@ -329,7 +336,7 @@ public class HomeController implements Initializable {
     void closeApp(MouseEvent event) {
         try {
             connection.closeConnection();
-            Main.stage.close();
+            context.getStage().close();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -337,7 +344,7 @@ public class HomeController implements Initializable {
 
     @FXML
     void minimizeApp(MouseEvent event) {
-        Main.stage.setIconified(true);
+        context.getStage().setIconified(true);
     }
 
     int findUser(String userName) {

--- a/src/Controllers/LogInController.java
+++ b/src/Controllers/LogInController.java
@@ -14,12 +14,16 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-public class LogInController implements Initializable {
+public class LogInController implements Initializable, ContextAware {
 
-    public static String userName;
+    private AppContext context;
     @FXML
     private JFXTextField userNameTextField;
 
+    @Override
+    public void setContext(AppContext context) {
+        this.context = context;
+    }
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -27,12 +31,12 @@ public class LogInController implements Initializable {
 
     @FXML
     void closeApp(MouseEvent event) {
-        Main.stage.close();
+        context.getStage().close();
     }
 
     @FXML
     void minimizeApp(MouseEvent event) {
-        Main.stage.setIconified(true);
+        context.getStage().setIconified(true);
     }
 
     @FXML
@@ -51,9 +55,21 @@ public class LogInController implements Initializable {
         }
 
         try {
-            userName = trimmedName;
-            Parent root = FXMLLoader.load(getClass().getResource("../Views/home_view.fxml"));
-            Main.stage.setScene(new Scene(root));
+            context.setUserName(trimmedName);
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("../Views/home_view.fxml"));
+            loader.setControllerFactory(type -> {
+                try {
+                    Object controller = type.getDeclaredConstructor().newInstance();
+                    if (controller instanceof ContextAware) {
+                        ((ContextAware) controller).setContext(context);
+                    }
+                    return controller;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            Parent root = loader.load();
+            context.getStage().setScene(new Scene(root));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/Controllers/Main.java
+++ b/src/Controllers/Main.java
@@ -8,16 +8,29 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
 public class Main extends Application {
-    public static Stage stage;
+
+    private AppContext context;
+
     @Override
-    public void start(Stage primaryStage) throws Exception{
-        Parent root = FXMLLoader.load(getClass().getResource("../Views/login_view.fxml"));
+    public void start(Stage primaryStage) throws Exception {
+        context = new AppContext(primaryStage);
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("../Views/login_view.fxml"));
+        loader.setControllerFactory(type -> {
+            try {
+                Object controller = type.getDeclaredConstructor().newInstance();
+                if (controller instanceof ContextAware) {
+                    ((ContextAware) controller).setContext(context);
+                }
+                return controller;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Parent root = loader.load();
         primaryStage.setScene(new Scene(root, 1280, 720));
         primaryStage.initStyle(StageStyle.UNDECORATED);
-        stage = primaryStage;
-        stage.show();
+        primaryStage.show();
     }
-
 
     public static void main(String[] args) {
         launch(args);


### PR DESCRIPTION
## Summary
- Replace global stage usage with `AppContext` and `ContextAware` to provide the primary `Stage` and logged-in user.
- Update `Main` to create and inject context into controllers via `FXMLLoader`.
- Adjust login and home controllers to use the injected context for window actions and username retrieval.

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `javac @sources.txt` *(fails: package javafx.scene.image does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68969ef967b08329b32df61efaf25547